### PR TITLE
カテゴリ分類のバックグラウンド化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,3 +85,4 @@ gem 'fog-aws'
 gem 'sassc'
 
 gem 'delayed_job_active_record'
+gem "daemons"

--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,5 @@ gem 'rmagick'
 gem 'fog-aws'
 
 gem 'sassc'
+
+gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,11 @@ GEM
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
     crass (1.0.4)
+    delayed_job (4.1.5)
+      activesupport (>= 3.0, < 5.3)
+    delayed_job_active_record (4.1.3)
+      activerecord (>= 3.0, < 5.3)
+      delayed_job (>= 3.0, < 5)
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -340,6 +345,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   carrierwave
   coffee-rails (~> 4.2)
+  delayed_job_active_record
   devise
   factory_bot_rails
   fog-aws

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
     crass (1.0.4)
+    daemons (1.2.6)
     delayed_job (4.1.5)
       activesupport (>= 3.0, < 5.3)
     delayed_job_active_record (4.1.3)
@@ -345,6 +346,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   carrierwave
   coffee-rails (~> 4.2)
+  daemons
   delayed_job_active_record
   devise
   factory_bot_rails

--- a/app/controllers/picks_controller.rb
+++ b/app/controllers/picks_controller.rb
@@ -146,7 +146,6 @@ class PicksController < ApplicationController
         :title,
         :body,
         {:user_ids => []}
-        # {:theme_ids => []}
         )
     end
 

--- a/app/controllers/picks_controller.rb
+++ b/app/controllers/picks_controller.rb
@@ -86,16 +86,15 @@ class PicksController < ApplicationController
     @pick.image = article_info[:image]
     @pick.source = article_info[:source]
 
-    #カテゴリー分け
-    text = @pick.title + ' ' + @pick.source
-    theme_id = Pick.categorize(text)
-
     if @pick.save
       flash[:notice] = "Pickしました"
-      pick_theme = PickTheme.new(pick_id: @pick.id, theme_id: theme_id)
-      pick_theme.save
       comment = Comment.new(pick_id: @pick.id, user_id: current_user.id, comment: params[:pick][:comments][:comment])
       comment.save
+
+      #カテゴリー分けバックグラウンド処理
+      text = @pick.title + ' ' + @pick.source
+      PickTheme.delay.register_theme(@pick, text)
+
       redirect_to :root
     else
       render action: :new

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,2 @@
 class ApplicationJob < ActiveJob::Base
-  queue_as :default
-
-  def perform(*args)
-    # Do something later
-  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,7 @@
 class ApplicationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(*args)
+    # Do something later
+  end
 end

--- a/app/models/pick_theme.rb
+++ b/app/models/pick_theme.rb
@@ -1,4 +1,12 @@
 class PickTheme < ApplicationRecord
   belongs_to :pick
   belongs_to :theme
+
+class << self
+  def register_theme(pick, text)
+    theme_id = Pick.categorize(text)
+    pick_theme = PickTheme.new(pick_id: pick.id, theme_id: theme_id)
+    pick_theme.save
+  end
+end
 end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,6 @@ module NewspicksTeama
       controller_specs: false
     end
     config.i18n.default_locale = :ja
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,4 @@
+Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.sleep_delay = 60
+Delayed::Worker.max_attempts = 3
+Delayed::Worker.max_run_time = 5.minutes

--- a/db/migrate/20180919074955_create_delayed_jobs.rb
+++ b/db/migrate/20180919074955_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.1]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180911083301) do
+ActiveRecord::Schema.define(version: 20180919074955) do
 
   create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text "comment"
@@ -21,6 +21,21 @@ ActiveRecord::Schema.define(version: 20180911083301) do
     t.index ["pick_id"], name: "index_comments_on_pick_id"
     t.index ["user_id", "pick_id"], name: "index_comments_on_user_id_and_pick_id", unique: true
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "dislikes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
# What
- Pickのカテゴリ分類の作業をバックグラウンド化する

# Why
- APIがデプロイされているherokuのサーバーがスリープ状態だと、時間がかかりすぎてUXに差し障るから